### PR TITLE
Fix parent group

### DIFF
--- a/crossword.el
+++ b/crossword.el
@@ -289,7 +289,7 @@
 
 (defgroup crossword nil
   "Settings for the Emacs crossword puzzle game/downloader."
-  :group 'crossword
+  :group 'games
   :prefix "crossword-")
 
 (defcustom crossword-save-path "~/Crosswords/"


### PR DESCRIPTION
Specifying `crossword` as the group for crossword creates an infinite loop of subgroups. This PR puts the group within the `games` parent group.